### PR TITLE
Add context support

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -1,6 +1,7 @@
 package algnhsa
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 
@@ -8,8 +9,8 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
-func handleEvent(event events.APIGatewayProxyRequest, handler http.Handler, binaryContentTypes map[string]bool) (events.APIGatewayProxyResponse, error) {
-	r, err := newHTTPRequest(event)
+func handleEvent(ctx context.Context, event events.APIGatewayProxyRequest, handler http.Handler, binaryContentTypes map[string]bool) (events.APIGatewayProxyResponse, error) {
+	r, err := newHTTPRequest(ctx, event)
 	if err != nil {
 		return events.APIGatewayProxyResponse{}, err
 	}
@@ -29,7 +30,7 @@ func ListenAndServe(handler http.Handler, binaryContentTypes []string) {
 	for _, contentType := range binaryContentTypes {
 		types[contentType] = true
 	}
-	lambda.Start(func(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-		return handleEvent(event, handler, types)
+	lambda.Start(func(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		return handleEvent(ctx, event, handler, types)
 	})
 }

--- a/context.go
+++ b/context.go
@@ -1,0 +1,21 @@
+package algnhsa
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+type key int
+
+const requestContextKey key = 0
+
+func newContext(ctx context.Context, event events.APIGatewayProxyRequest) context.Context {
+	return context.WithValue(ctx, requestContextKey, event)
+}
+
+// ProxyRequestFromContext extracts the APIGatewayProxyRequest event from ctx.
+func ProxyRequestFromContext(ctx context.Context) (events.APIGatewayProxyRequest, bool) {
+	event, ok := ctx.Value(requestContextKey).(events.APIGatewayProxyRequest)
+	return event, ok
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,34 @@
+package algnhsa_test
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/akrylysov/algnhsa"
+)
+
+func indexHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("index"))
+}
+
+func addHandler(w http.ResponseWriter, r *http.Request) {
+	f, _ := strconv.Atoi(r.FormValue("first"))
+	s, _ := strconv.Atoi(r.FormValue("second"))
+	w.Header().Set("X-Hi", "foo")
+	fmt.Fprintf(w, "%d", f+s)
+}
+
+func contextHandler(w http.ResponseWriter, r *http.Request) {
+	proxyReq, ok := algnhsa.ProxyRequestFromContext(r.Context())
+	if ok {
+		fmt.Fprint(w, proxyReq.RequestContext.AccountID)
+	}
+}
+
+func Example() {
+	http.HandleFunc("/", indexHandler)
+	http.HandleFunc("/add", addHandler)
+	http.HandleFunc("/context", contextHandler)
+	algnhsa.ListenAndServe(http.DefaultServeMux, nil)
+}

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package algnhsa
 
 import (
+	"context"
 	"encoding/base64"
 	"io"
 	"net/http"
@@ -10,7 +11,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-func newHTTPRequest(event events.APIGatewayProxyRequest) (*http.Request, error) {
+func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest) (*http.Request, error) {
 	// Build request URL.
 	params := url.Values{}
 	for k, v := range event.QueryStringParameters {
@@ -41,5 +42,5 @@ func newHTTPRequest(event events.APIGatewayProxyRequest) (*http.Request, error) 
 	// Set remote IP address.
 	r.RemoteAddr = event.RequestContext.Identity.SourceIP
 
-	return r, nil
+	return r.WithContext(newContext(ctx, event)), nil
 }


### PR DESCRIPTION
- Makes `handleEvent` pass the lambda context to handlers.
- Adds `ProxyRequestFromContext` function that provides access to the original `APIGatewayProxyRequest` event.