### PR TITLE
ensure http.Request has a Host

### DIFF
--- a/adapter_test.go
+++ b/adapter_test.go
@@ -66,6 +66,9 @@ func TestHandleEvent(t *testing.T) {
 			w.Write([]byte("ok"))
 		}
 	})
+	r.HandleFunc("/hostname", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.Host))
+	})
 	testCases := []struct {
 		req                events.APIGatewayProxyRequest
 		resp               events.APIGatewayProxyResponse
@@ -222,6 +225,21 @@ func TestHandleEvent(t *testing.T) {
 			resp: events.APIGatewayProxyResponse{
 				StatusCode: 200,
 				Body:       "ok",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/hostname",
+				Headers: map[string]string{
+					"Host": "bar",
+				},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Headers: map[string]string{
+					"Content-Type": "text/plain; charset=utf-8",
+				},
+				Body: "bar",
 			},
 		},
 	}

--- a/request.go
+++ b/request.go
@@ -18,10 +18,10 @@ func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest) (*
 		params.Set(k, v)
 	}
 	u := url.URL{
+		Host:     event.Headers["Host"],
 		Path:     event.Path,
 		RawQuery: params.Encode(),
 	}
-
 	// Handle base64 encoded body.
 	var body io.Reader = strings.NewReader(event.Body)
 	if event.IsBase64Encoded {


### PR DESCRIPTION
set the Host field for the http request to enable x-ray / logging for incoming http requests. 