### PR TITLE
Extract the AwsRequestID into it's own context value

### DIFF
--- a/context.go
+++ b/context.go
@@ -4,13 +4,24 @@ import (
 	"context"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambdacontext"
 )
 
 type key int
 
-const requestContextKey key = 0
+const (
+	requestContextKey key = iota
+	requestIDContextKey
+)
 
 func newContext(ctx context.Context, event events.APIGatewayProxyRequest) context.Context {
+
+	// if the lambdacontext exists extract the the requestID into something
+	// less lambda specific
+	if lc, ok := lambdacontext.FromContext(ctx); ok {
+		ctx = context.WithValue(ctx, requestIDContextKey, lc.AwsRequestID)
+	}
+
 	return context.WithValue(ctx, requestContextKey, event)
 }
 
@@ -18,4 +29,10 @@ func newContext(ctx context.Context, event events.APIGatewayProxyRequest) contex
 func ProxyRequestFromContext(ctx context.Context) (events.APIGatewayProxyRequest, bool) {
 	event, ok := ctx.Value(requestContextKey).(events.APIGatewayProxyRequest)
 	return event, ok
+}
+
+// RequestIDFromContext extracts the APIGatewayProxyRequest event from ctx
+func RequestIDFromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(requestIDContextKey).(string)
+	return id, ok
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,60 @@
+package algnhsa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambdacontext"
+)
+
+func TestNewContext(t *testing.T) {
+
+	ctx := context.Background()
+
+	apigwReq := events.APIGatewayProxyRequest{}
+
+	// create a generic empty request context
+	reqCtx := newContext(ctx, apigwReq)
+
+	val, ok := RequestIDFromContext(reqCtx)
+	if val != "" || ok {
+		t.Fatalf("Expected the requestIDContextKey to be empty but got %v", val)
+	}
+
+	lc := lambdacontext.NewContext(ctx, &lambdacontext.LambdaContext{
+		AwsRequestID: "test",
+	})
+
+	// now create a context from a lambda context
+	lambdaReqCtx := newContext(lc, apigwReq)
+
+	val, _ = RequestIDFromContext(lambdaReqCtx)
+	if val != "test" {
+		t.Fatalf("Expected %v but got %v when extracting requestIDContextKey", "test", val)
+	}
+
+}
+
+func TestRequestIDFromContext(t *testing.T) {
+
+	ctx := context.Background()
+
+	val, ok := RequestIDFromContext(ctx)
+	if ok {
+		t.Fatal("Expected ok to be false but got true")
+	}
+	if val != "" {
+		t.Fatalf("Expected val to be empty but got %v", val)
+	}
+
+	ctx = context.WithValue(ctx, requestIDContextKey, "test")
+
+	val, ok = RequestIDFromContext(ctx)
+	if !ok {
+		t.Fatal("Expected ok to be true but got false")
+	}
+	if val != "test" {
+		t.Fatalf("Expected %v but got %v", "test", val)
+	}
+}


### PR DESCRIPTION
This allows us to access the `AwsRequestID` a bit more seamlessly.
Also adds some tests 🤖 