### PR TITLE
Workaround for AWS Gateway multiheaders

### DIFF
--- a/response.go
+++ b/response.go
@@ -3,11 +3,39 @@ package algnhsa
 import (
 	"encoding/base64"
 	"net/http/httptest"
+	"unicode"
 
 	"github.com/aws/aws-lambda-go/events"
 )
 
 const acceptAllContentType = "*/*"
+
+// binaryCase ported from https://github.com/Gi60s/binary-case/blob/b100ba0d63075c28485fd1724d94746f74742107/index.js#L86
+func binaryCase(s string, n int) string {
+	inp := []rune(s)
+	var res []rune
+
+	for i, c := range inp {
+		if n == 0 {
+			res = append(res, inp[i:]...)
+			break
+		}
+		if c <= unicode.MaxASCII && unicode.IsUpper(c) {
+			if n&1 > 0 {
+				c += 32
+			}
+			n >>= 1
+		} else if c <= unicode.MaxASCII && unicode.IsLower(c) {
+			if n&1 > 0 {
+				c -= 32
+			}
+			n >>= 1
+		}
+		res = append(res, c)
+	}
+
+	return string(res)
+}
 
 func newAPIGatewayResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool) (events.APIGatewayProxyResponse, error) {
 	event := events.APIGatewayProxyResponse{}
@@ -18,7 +46,10 @@ func newAPIGatewayResponse(w *httptest.ResponseRecorder, binaryContentTypes map[
 	// Set headers.
 	respHeaders := map[string]string{}
 	for k, v := range w.HeaderMap {
-		respHeaders[k] = v[0]
+		// Workaround for https://forums.aws.amazon.com/thread.jspa?threadID=205782
+		for i, val := range v {
+			respHeaders[binaryCase(k, i)] = val
+		}
 	}
 	event.Headers = respHeaders
 

--- a/response_test.go
+++ b/response_test.go
@@ -1,0 +1,21 @@
+package algnhsa
+
+import "testing"
+
+func TestBinaryCase(t *testing.T) {
+	if binaryCase("ab", 0) != "ab" {
+		t.Errorf("binaryCase (ab,0) expected %s observed %s", "ab", binaryCase("ab", 0))
+	}
+	if binaryCase("ab", 1) != "Ab" {
+		t.Errorf("binaryCase (ab,1) expected %s observed %s", "Ab", binaryCase("ab", 1))
+	}
+	if binaryCase("ab", 2) != "aB" {
+		t.Errorf("binaryCase (ab,2) expected %s observed %s", "aB", binaryCase("ab", 2))
+	}
+	if binaryCase("ab", 3) != "AB" {
+		t.Errorf("binaryCase (ab,3) expected %s observed %s", "AB", binaryCase("ab", 3))
+	}
+	if binaryCase("a----b", 3) != "A----B" {
+		t.Errorf("binaryCase (a----b,3) expected %s observed %s", "A----B", binaryCase("a----b", 3))
+	}
+}


### PR DESCRIPTION
Use uppercase/lowercase variations for http headers as a workaround for AWS Gateway not supporting the
specification for http headers. See https://forums.aws.amazon.com/thread.jspa?threadID=205782