### PR TITLE
Support multi-value query string parameters and headers in requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9] - 2018-12-10
+### Added
+- Support multi-value query string parameters and headers in requests.
+
 ## [0.8] - 2018-07-29
 ### Added
 - Workaround for API Gateway not supporting headers with multiple values.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,5 @@ func main() {
 ```
 
 More details at http://artem.krylysov.com/blog/2018/01/18/porting-go-web-applications-to-aws-lambda/.
+
+Note: algnhsa requires [aws-lambda-go](https://github.com/aws/aws-lambda-go) version 1.8.0 or higher.

--- a/request.go
+++ b/request.go
@@ -18,6 +18,9 @@ func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, us
 	for k, v := range event.QueryStringParameters {
 		params.Set(k, v)
 	}
+	for k, vals := range event.MultiValueQueryStringParameters {
+		params[k] = vals
+	}
 	u := url.URL{
 		Host:     event.Headers["Host"],
 		Path:     event.Path,
@@ -40,8 +43,15 @@ func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, us
 	}
 
 	// Set headers.
+	// https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+	// If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list.
+	// If the same key-value pair is specified in both, only the values from multiValueHeaders will appear
+	// the merged list.
 	for k, v := range event.Headers {
 		r.Header.Set(k, v)
+	}
+	for k, vals := range event.MultiValueHeaders {
+		r.Header[http.CanonicalHeaderKey(k)] = vals
 	}
 
 	// Set remote IP address.


### PR DESCRIPTION
Adds support of multi-value query string parameters and headers in requests. See https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/ for more details.