### PR TITLE
Setting the RequestURI

### DIFF
--- a/adapter_test.go
+++ b/adapter_test.go
@@ -70,6 +70,9 @@ func TestHandleEvent(t *testing.T) {
 	r.HandleFunc("/hostname", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(r.Host))
 	})
+	r.HandleFunc("/requesturi", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.RequestURI))
+	})
 	testCases := []struct {
 		req  events.APIGatewayProxyRequest
 		opts *Options
@@ -269,6 +272,18 @@ func TestHandleEvent(t *testing.T) {
 			resp: events.APIGatewayProxyResponse{
 				StatusCode: 200,
 				Body:       "ok",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/requesturi",
+				QueryStringParameters: map[string]string{
+					"foo": "bar",
+				},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "/requesturi?foo=bar",
 			},
 		},
 	}

--- a/request.go
+++ b/request.go
@@ -57,5 +57,8 @@ func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, us
 	// Set remote IP address.
 	r.RemoteAddr = event.RequestContext.Identity.SourceIP
 
+	// Set request URI
+	r.RequestURI = u.RequestURI()
+
 	return r.WithContext(newContext(ctx, event)), nil
 }


### PR DESCRIPTION
The RequestURI was not set on the request. This should set it to what the server thinks it would have been.