### PR TITLE
ALB target group support

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -3,34 +3,44 @@ package algnhsa
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 
+	"github.com/akrylysov/algnhsa/alb"
+	"github.com/akrylysov/algnhsa/apigw"
+	"github.com/akrylysov/algnhsa/config"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/mitchellh/mapstructure"
 )
 
-func handleEvent(ctx context.Context, event events.APIGatewayProxyRequest, handler http.Handler, opts *Options) (events.APIGatewayProxyResponse, error) {
-	r, err := newHTTPRequest(ctx, event, opts.UseProxyPath)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
+func handleEvent(ctx context.Context, event map[string]interface{}, handler http.Handler, opts *config.Options) (response interface{}, err error) {
+
+	_, isAPIGatewayRequest := event["resource"]
+
+	if isAPIGatewayRequest {
+		var request events.APIGatewayProxyRequest
+		mapstructure.Decode(event, &request)
+		response, err = apigw.HandleEvent(ctx, request, handler, opts)
+	} else {
+		var request events.ALBTargetGroupRequest
+		mapstructure.Decode(event, &request)
+		response, err = alb.HandleEvent(ctx, request, handler, opts)
 	}
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
-	return newAPIGatewayResponse(w, opts.binaryContentTypeMap)
+
+	return
 }
 
-var defaultOptions = &Options{}
+var defaultOptions = &config.Options{}
 
 // ListenAndServe starts the AWS Lambda runtime (aws-lambda-go lambda.Start) with a given handler.
-func ListenAndServe(handler http.Handler, opts *Options) {
+func ListenAndServe(handler http.Handler, opts *config.Options) {
 	if handler == nil {
 		handler = http.DefaultServeMux
 	}
 	if opts == nil {
 		opts = defaultOptions
 	}
-	opts.setBinaryContentTypeMap()
-	lambda.Start(func(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	opts.SetBinaryContentTypeMap()
+	lambda.Start(func(ctx context.Context, event map[string]interface{}) (interface{}, error) {
 		return handleEvent(ctx, event, handler, opts)
 	})
 }

--- a/alb/adapter.go
+++ b/alb/adapter.go
@@ -1,0 +1,24 @@
+package alb
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/akrylysov/algnhsa/config"
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func HandleEvent(ctx context.Context, request events.ALBTargetGroupRequest, handler http.Handler, opts *config.Options) (interface{}, error) {
+
+	multiValue := len(request.MultiValueHeaders) > 0
+
+	r, err := NewHTTPRequest(ctx, request)
+	if err != nil {
+		return events.ALBTargetGroupResponse{}, err
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	return NewALBResponse(w, opts.BinaryContentTypeMap, multiValue)
+
+}

--- a/alb/adapter.go
+++ b/alb/adapter.go
@@ -9,16 +9,16 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
+// HandleEvent translates an ALBTargetGroupRequest for use by an http.Handler
 func HandleEvent(ctx context.Context, request events.ALBTargetGroupRequest, handler http.Handler, opts *config.Options) (interface{}, error) {
-
-	multiValue := len(request.MultiValueHeaders) > 0
-
-	r, err := NewHTTPRequest(ctx, request)
+	r, err := newHTTPRequest(ctx, request)
 	if err != nil {
 		return events.ALBTargetGroupResponse{}, err
 	}
+
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
-	return NewALBResponse(w, opts.BinaryContentTypeMap, multiValue)
 
+	multiValue := len(request.MultiValueHeaders) > 0
+	return newALBResponse(w, opts.BinaryContentTypeMap, multiValue)
 }

--- a/alb/context.go
+++ b/alb/context.go
@@ -1,0 +1,21 @@
+package alb
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+type key int
+
+const requestContextKey key = 0
+
+func newContext(ctx context.Context, event events.ALBTargetGroupRequest) context.Context {
+	return context.WithValue(ctx, requestContextKey, event)
+}
+
+// ProxyRequestFromContext extracts the APIGatewayProxyRequest event from ctx.
+func ProxyRequestFromContext(ctx context.Context) (events.ALBTargetGroupRequest, bool) {
+	event, ok := ctx.Value(requestContextKey).(events.ALBTargetGroupRequest)
+	return event, ok
+}

--- a/alb/context.go
+++ b/alb/context.go
@@ -14,8 +14,8 @@ func newContext(ctx context.Context, event events.ALBTargetGroupRequest) context
 	return context.WithValue(ctx, requestContextKey, event)
 }
 
-// ProxyRequestFromContext extracts the APIGatewayProxyRequest event from ctx.
-func ProxyRequestFromContext(ctx context.Context) (events.ALBTargetGroupRequest, bool) {
+// TargetGroupRequestFromContext extracts the ALBTargetGroupRequest event from ctx.
+func TargetGroupRequestFromContext(ctx context.Context) (events.ALBTargetGroupRequest, bool) {
 	event, ok := ctx.Value(requestContextKey).(events.ALBTargetGroupRequest)
 	return event, ok
 }

--- a/alb/request.go
+++ b/alb/request.go
@@ -1,0 +1,81 @@
+package alb
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func NewHTTPRequest(ctx context.Context, event events.ALBTargetGroupRequest) (*http.Request, error) {
+
+	// headers will always be set in one or the other depending
+	// on whether or not the target group has use-multi enabled
+	multiValue := len(event.MultiValueHeaders) > 0
+
+	// Build request URL.
+	params := url.Values{}
+
+	if multiValue {
+		for k, vals := range event.MultiValueQueryStringParameters {
+			params[k] = vals
+		}
+	} else {
+		for k, v := range event.QueryStringParameters {
+			params.Set(k, v)
+		}
+
+	}
+
+	u := url.URL{
+		Host:     event.Headers["Host"],
+		RawPath:  event.Path,
+		RawQuery: params.Encode(),
+	}
+
+	// Unescape request path
+	p, err := url.PathUnescape(u.RawPath)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = p
+
+	if u.Path == u.RawPath {
+		u.RawPath = ""
+	}
+
+	// Handle base64 encoded body.
+	var body io.Reader = strings.NewReader(event.Body)
+	if event.IsBase64Encoded {
+		body = base64.NewDecoder(base64.StdEncoding, body)
+	}
+
+	// Create a new request.
+	r, err := http.NewRequest(event.HTTPMethod, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set headers.
+	if multiValue {
+		for k, vals := range event.MultiValueHeaders {
+			r.Header[http.CanonicalHeaderKey(k)] = vals
+		}
+	} else {
+		for k, v := range event.Headers {
+			r.Header.Set(k, v)
+		}
+	}
+
+	// There doesn't seem to be a way to get source IP from an ALB request
+	//r.RemoteAddr = event.RequestContext.Identity.SourceIP
+
+	// Set request URI
+	r.RequestURI = u.RequestURI()
+
+	return r.WithContext(newContext(ctx, event)), nil
+}

--- a/alb/request.go
+++ b/alb/request.go
@@ -38,9 +38,16 @@ func newHTTPRequest(ctx context.Context, event events.ALBTargetGroupRequest) (*h
 	}
 
 	u := url.URL{
-		Host:     event.Headers["Host"],
 		RawPath:  event.Path,
 		RawQuery: params.Encode(),
+	}
+
+	if multiValue {
+		if len(event.MultiValueHeaders["Host"]) > 0 {
+			u.Host = event.MultiValueHeaders["Host"][0]
+		}
+	} else {
+		u.Host = event.Headers["Host"]
 	}
 
 	// Unescape request path

--- a/alb/response.go
+++ b/alb/response.go
@@ -1,0 +1,45 @@
+package alb
+
+import (
+	"encoding/base64"
+	"net/http/httptest"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+const acceptAllContentType = "*/*"
+
+func NewALBResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool, multiValue bool) (events.ALBTargetGroupResponse, error) {
+	event := events.ALBTargetGroupResponse{}
+
+	// Set status code.
+	event.StatusCode = w.Code
+
+	// Per AWS docs: You must use multiValueHeaders if you have enabled multi-value headers and headers otherwise
+	// In practice - leaving headers null when multi-value is enabled (and vice versa) result in the ALB
+	// returning a 502 Bad Gateway
+	if multiValue {
+		event.MultiValueHeaders = w.Result().Header
+	} else {
+
+		singleValueHeaders := make(map[string]string)
+
+		// we can only return one header for each key, so use the first
+		for key := range w.Result().Header {
+			singleValueHeaders[key] = w.Result().Header.Get(key)
+		}
+
+		event.Headers = singleValueHeaders
+	}
+
+	// Set body.
+	contentType := w.Header().Get("Content-Type")
+	if binaryContentTypes[acceptAllContentType] || binaryContentTypes[contentType] {
+		event.Body = base64.StdEncoding.EncodeToString(w.Body.Bytes())
+		event.IsBase64Encoded = true
+	} else {
+		event.Body = w.Body.String()
+	}
+
+	return event, nil
+}

--- a/alb/response.go
+++ b/alb/response.go
@@ -9,7 +9,7 @@ import (
 
 const acceptAllContentType = "*/*"
 
-func NewALBResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool, multiValue bool) (events.ALBTargetGroupResponse, error) {
+func newALBResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool, multiValue bool) (events.ALBTargetGroupResponse, error) {
 	event := events.ALBTargetGroupResponse{}
 
 	// Set status code.

--- a/apigw/adapter.go
+++ b/apigw/adapter.go
@@ -1,0 +1,22 @@
+package apigw
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/akrylysov/algnhsa/config"
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func HandleEvent(ctx context.Context, request events.APIGatewayProxyRequest, handler http.Handler, opts *config.Options) (events.APIGatewayProxyResponse, error) {
+
+	r, err := NewHTTPRequest(ctx, request, opts.UseProxyPath)
+	if err != nil {
+		return events.APIGatewayProxyResponse{}, err
+	}
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	return NewAPIGatewayResponse(w, opts.BinaryContentTypeMap)
+
+}

--- a/apigw/adapter.go
+++ b/apigw/adapter.go
@@ -11,12 +11,12 @@ import (
 
 func HandleEvent(ctx context.Context, request events.APIGatewayProxyRequest, handler http.Handler, opts *config.Options) (events.APIGatewayProxyResponse, error) {
 
-	r, err := NewHTTPRequest(ctx, request, opts.UseProxyPath)
+	r, err := newHTTPRequest(ctx, request, opts.UseProxyPath)
 	if err != nil {
 		return events.APIGatewayProxyResponse{}, err
 	}
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, r)
-	return NewAPIGatewayResponse(w, opts.BinaryContentTypeMap)
+	return newAPIGatewayResponse(w, opts.BinaryContentTypeMap)
 
 }

--- a/apigw/adapter_test.go
+++ b/apigw/adapter_test.go
@@ -1,0 +1,327 @@
+package apigw
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/akrylysov/algnhsa/config"
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func assertDeepEqual(t *testing.T, expected interface{}, actual interface{}, testCase interface{}) {
+	t.Helper()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\nexpected %+v\ngot      %+v\ntest case: %+v", expected, actual, testCase)
+	}
+}
+
+func TestHandleEvent(t *testing.T) {
+	r := http.NewServeMux()
+	r.HandleFunc("/html", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("<html>foo</html>"))
+	})
+	r.HandleFunc("/text", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+	r.HandleFunc("/query-params", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		fmt.Fprintf(w, "a=%s, b=%s, c=%s, unknown=%v", r.Form["a"], r.Form["b"], r.Form["c"], r.Form["unknown"])
+	})
+	r.HandleFunc("/path/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.URL.Path))
+	})
+	r.HandleFunc("/post-body", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				fmt.Fprintf(w, "%v", err)
+			} else {
+				w.Write(body)
+			}
+		}
+	})
+	r.HandleFunc("/form", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.Write([]byte(r.FormValue("f") + r.FormValue("s") + r.FormValue("unknown")))
+		}
+	})
+	r.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/gif")
+		w.WriteHeader(204)
+	})
+	r.HandleFunc("/headers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-A") == "1" && reflect.DeepEqual(r.Header["X-B"], []string{"21", "22"}) {
+			w.Header().Set("X-Bar", "baz")
+			w.Header().Add("X-y", "1")
+			w.Header().Add("X-Y", "2")
+			w.Write([]byte("ok"))
+		}
+	})
+	r.HandleFunc("/context", func(w http.ResponseWriter, r *http.Request) {
+		expectedProxyReq := events.APIGatewayProxyRequest{
+			Path: "/context",
+			RequestContext: events.APIGatewayProxyRequestContext{
+				AccountID: "foo",
+			},
+		}
+		proxyReq, ok := ProxyRequestFromContext(r.Context())
+		if ok && reflect.DeepEqual(expectedProxyReq, proxyReq) {
+			w.Write([]byte("ok"))
+		}
+	})
+	r.HandleFunc("/hostname", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.Host))
+	})
+	r.HandleFunc("/requesturi", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.RequestURI))
+	})
+	testCases := []struct {
+		req  events.APIGatewayProxyRequest
+		opts *config.Options
+		resp events.APIGatewayProxyResponse
+	}{
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/html",
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode:        200,
+				Body:              "<html>foo</html>",
+				MultiValueHeaders: map[string][]string{"Content-Type": {"text/html; charset=utf-8"}},
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/text",
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "ok",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/query-params",
+				QueryStringParameters: map[string]string{
+					"a": "1",
+					"b": "",
+				},
+				MultiValueQueryStringParameters: map[string][]string{
+					"b": {"2"},
+					"c": {"31", "32", "33"},
+				},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "a=[1], b=[2], c=[31 32 33], unknown=[]",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/path/encode%2Ftest%7C",
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "/path/encode/test|",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				HTTPMethod: "POST",
+				Path:       "/post-body",
+				Body:       "foobar",
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "foobar",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				HTTPMethod:      "POST",
+				Path:            "/post-body",
+				Body:            "Zm9vYmFy",
+				IsBase64Encoded: true,
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "foobar",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				HTTPMethod: "POST",
+				Path:       "/form",
+				MultiValueHeaders: map[string][]string{
+					"Content-Type":   {"application/x-www-form-urlencoded"},
+					"Content-Length": {"19"},
+				},
+				Body: "f=foo&s=bar&xyz=123",
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "foobar",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/status",
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode:        204,
+				MultiValueHeaders: map[string][]string{"Content-Type": {"image/gif"}},
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/headers",
+				Headers: map[string]string{
+					"X-a": "1",
+					"x-b": "2",
+				},
+				MultiValueHeaders: map[string][]string{
+					"x-B": {"21", "22"},
+				},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				MultiValueHeaders: map[string][]string{
+					"Content-Type": {"text/plain; charset=utf-8"},
+					"X-Bar":        {"baz"},
+					"X-Y":          {"1", "2"},
+				},
+				Body: "ok",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/text",
+			},
+			opts: &config.Options{
+				BinaryContentTypes: []string{"text/plain; charset=utf-8"},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode:      200,
+				Body:            "b2s=",
+				IsBase64Encoded: true,
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/text",
+			},
+			opts: &config.Options{
+				BinaryContentTypes: []string{"*/*"},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode:      200,
+				Body:            "b2s=",
+				IsBase64Encoded: true,
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/text",
+			},
+			opts: &config.Options{
+				BinaryContentTypes: []string{"text/html; charset=utf-8"},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "ok",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/404",
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 404,
+				Body:       "404 page not found\n",
+				MultiValueHeaders: map[string][]string{
+					"Content-Type":           {"text/plain; charset=utf-8"},
+					"X-Content-Type-Options": {"nosniff"},
+				},
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/context",
+				RequestContext: events.APIGatewayProxyRequestContext{
+					AccountID: "foo",
+				},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "ok",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/hostname",
+				Headers: map[string]string{
+					"Host": "bar",
+				},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				MultiValueHeaders: map[string][]string{
+					"Content-Type": {"text/plain; charset=utf-8"},
+				},
+				Body: "bar",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/stage/text",
+				PathParameters: map[string]string{
+					"proxy": "text",
+				},
+			},
+			opts: &config.Options{
+				UseProxyPath: true,
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "ok",
+			},
+		},
+		{
+			req: events.APIGatewayProxyRequest{
+				Path: "/requesturi",
+				QueryStringParameters: map[string]string{
+					"foo": "bar",
+				},
+			},
+			resp: events.APIGatewayProxyResponse{
+				StatusCode: 200,
+				Body:       "/requesturi?foo=bar",
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		req := testCase.req
+		if req.HTTPMethod == "" {
+			req.HTTPMethod = "GET"
+		}
+		expectedResp := testCase.resp
+		if expectedResp.MultiValueHeaders == nil {
+			expectedResp.MultiValueHeaders = map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}}
+		}
+		opts := testCase.opts
+		if opts == nil {
+			opts = &config.Options{}
+		}
+		opts.SetBinaryContentTypeMap()
+		ctx := context.Background()
+		resp, err := HandleEvent(ctx, testCase.req, r, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertDeepEqual(t, expectedResp, resp, testCase)
+	}
+}

--- a/apigw/context.go
+++ b/apigw/context.go
@@ -1,4 +1,4 @@
-package algnhsa
+package apigw
 
 import (
 	"context"

--- a/apigw/request.go
+++ b/apigw/request.go
@@ -1,4 +1,4 @@
-package algnhsa
+package apigw
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, useProxyPath bool) (*http.Request, error) {
+func NewHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, useProxyPath bool) (*http.Request, error) {
 	// Build request URL.
 	params := url.Values{}
 	for k, v := range event.QueryStringParameters {

--- a/apigw/request.go
+++ b/apigw/request.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-func NewHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, useProxyPath bool) (*http.Request, error) {
+func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, useProxyPath bool) (*http.Request, error) {
 	// Build request URL.
 	params := url.Values{}
 	for k, v := range event.QueryStringParameters {

--- a/apigw/response.go
+++ b/apigw/response.go
@@ -1,4 +1,4 @@
-package algnhsa
+package apigw
 
 import (
 	"encoding/base64"
@@ -9,7 +9,7 @@ import (
 
 const acceptAllContentType = "*/*"
 
-func newAPIGatewayResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool) (events.APIGatewayProxyResponse, error) {
+func NewAPIGatewayResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool) (events.APIGatewayProxyResponse, error) {
 	event := events.APIGatewayProxyResponse{}
 
 	// Set status code.

--- a/apigw/response.go
+++ b/apigw/response.go
@@ -9,7 +9,7 @@ import (
 
 const acceptAllContentType = "*/*"
 
-func NewAPIGatewayResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool) (events.APIGatewayProxyResponse, error) {
+func newAPIGatewayResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool) (events.APIGatewayProxyResponse, error) {
 	event := events.APIGatewayProxyResponse{}
 
 	// Set status code.

--- a/config/options.go
+++ b/config/options.go
@@ -1,21 +1,21 @@
-package algnhsa
+package config
 
 // Options holds the optional parameters.
 type Options struct {
 	// BinaryContentTypes sets content types that should be treated as binary types by API Gateway.
 	// The "*/* value makes algnhsa treat any content type as binary.
 	BinaryContentTypes   []string
-	binaryContentTypeMap map[string]bool
+	BinaryContentTypeMap map[string]bool
 
 	// Use API Gateway PathParameters["proxy"] when constructing the request url.
 	// Strips the base path mapping when using a custom domain with API Gateway.
 	UseProxyPath bool
 }
 
-func (opts *Options) setBinaryContentTypeMap() {
+func (opts *Options) SetBinaryContentTypeMap() {
 	types := map[string]bool{}
 	for _, contentType := range opts.BinaryContentTypes {
 		types[contentType] = true
 	}
-	opts.binaryContentTypeMap = types
+	opts.BinaryContentTypeMap = types
 }

--- a/example_test.go
+++ b/example_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/akrylysov/algnhsa"
+	"github.com/akrylysov/algnhsa/apigw"
 )
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
@@ -20,7 +21,7 @@ func addHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func contextHandler(w http.ResponseWriter, r *http.Request) {
-	proxyReq, ok := algnhsa.ProxyRequestFromContext(r.Context())
+	proxyReq, ok := apigw.ProxyRequestFromContext(r.Context())
 	if ok {
 		fmt.Fprint(w, proxyReq.RequestContext.AccountID)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.12
 
 require (
 	github.com/aws/aws-lambda-go v1.9.0
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/stretchr/testify v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-lambda-go v1.9.0 h1:r9TWtk8ozLYdMW+aelUeWny8z2mjghJCMx6/uUwOL
 github.com/aws/aws-lambda-go v1.9.0/go.mod h1:zUsUQhAUjYzR8AuduJPCfhBuKWUaDbQiPOG+ouzmE1A=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
+github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Enables support for ALB target groups.

Structurally, the existing code for API Gateway targets is untouched, and has been moved under `apigw/` with the new ALB target group code under `alb/`  

The base `algnhsa.handleEvent()` function now determines for each request whether it's an ALB or API Gateway request by accepting the Lambda event as a generic `map[string]interface{}` instead of a specific type and checking for a `"resource"` key, which indicates that it's an API Gateway request if present.  It then "casts" the generic `map` to the appropriate concrete type (e.g. `events.ALBTargetGroupRequest`) and the logic splits into either the `alb` or `apigateway` package.

I tore my hair out over the design decision to split the logic into 2 different but similar packages, because there's a fair amount of code duplication, at least at first glance.  The underlying data structures are aggravatingly similar, but just different enough to require different handling.  

Ultimately, trying to do it all in one package turned it into a spaghetti of nested `if/else` statements, because ALB target group requests handle single/multi-value requests much differently than API Gateway does. The code became unreadable and I felt the duplication was justified.  If the library ends up supporting a 3rd request type, I think it would be time to do some refactoring for common logic.

The primary difference that caused the spaghetti is that ALB target group requests do not merge single- and multi-value headers like API Gateway requests do.  See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers for details.  But in short: If the target group has multi-value headers enabled, only the `MultiValueHeaders` and `MultiValueQueryParameters` fields will be set in the request, and most importantly, the response **must** have `MultiValueHeaders` set and `Headers` empty, or the ALB will return a 500 error (and vice-versa).

I have updated the `alb/adapter_test.go` unit tests to handle a variety of single and multi-value requests and responses.  The unit tests under `apigw/` remain the same as before this PR.