### PR TITLE
Add ALB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 algnhsa is an AWS Lambda Go `net/http` server adapter.
 
-algnhsa enables running Go web applications on AWS Lambda/API Gateway without changing the existing HTTP handlers:
+algnhsa enables running Go web applications on AWS Lambda and API Gateway or ALB without changing the existing HTTP handlers:
 
 ```go
 package main
@@ -41,7 +41,7 @@ func main() {
 }
 ```
 
-Plug in a third-party HTTP router:
+## Plug in a third-party HTTP router
 
 ```go
 package main
@@ -62,10 +62,20 @@ func main() {
 }
 ```
 
-More details at http://artem.krylysov.com/blog/2018/01/18/porting-go-web-applications-to-aws-lambda/.
+## Setting up API Gateway 
 
-Note: algnhsa requires [aws-lambda-go](https://github.com/aws/aws-lambda-go) version 1.8.1 or higher:
+1. Create a new REST API.
 
-```sh
-go get -u github.com/aws/aws-lambda-go/events
-```
+2. In the "Resources" section create a new `ANY` method to handle requests to `/` (check "Use Lambda Proxy Integration").
+
+    ![API Gateway index](https://akrylysov.github.io/algnhsa/apigateway-index.png)
+
+3. Add a catch-all `{proxy+}` resource to handle requests to every other path (check "Configure as proxy resource").
+
+    ![API Gateway catch-all](https://akrylysov.github.io/algnhsa/apigateway-catchall.png)
+
+## Setting up ALB
+
+1. Create a new ALB and point it to your Lambda function.
+
+2. In the target group settings enable "Multi value headers".

--- a/adapter.go
+++ b/adapter.go
@@ -21,13 +21,7 @@ func (handler lambdaHandler) Invoke(ctx context.Context, payload []byte) ([]byte
 	if err != nil {
 		return nil, err
 	}
-
-	respPayload, err := json.Marshal(resp)
-	if err != nil {
-		return nil, err
-	}
-
-	return respPayload, nil
+	return json.Marshal(resp)
 }
 
 func (handler lambdaHandler) handleEvent(ctx context.Context, payload []byte) (lambdaResponse, error) {

--- a/adapter.go
+++ b/adapter.go
@@ -2,24 +2,47 @@ package algnhsa
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
-func handleEvent(ctx context.Context, event events.APIGatewayProxyRequest, handler http.Handler, opts *Options) (events.APIGatewayProxyResponse, error) {
-	r, err := newHTTPRequest(ctx, event, opts.UseProxyPath)
-	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
-	}
-	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, r)
-	return newAPIGatewayResponse(w, opts.binaryContentTypeMap)
+var defaultOptions = &Options{}
+
+type lambdaHandler struct {
+	httpHandler http.Handler
+	opts        *Options
 }
 
-var defaultOptions = &Options{}
+func (handler lambdaHandler) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
+	resp, err := handler.handleEvent(ctx, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	respPayload, err := json.Marshal(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return respPayload, nil
+}
+
+func (handler lambdaHandler) handleEvent(ctx context.Context, payload []byte) (lambdaResponse, error) {
+	eventReq, err := newLambdaRequest(ctx, payload, handler.opts)
+	if err != nil {
+		return lambdaResponse{}, err
+	}
+	r, err := newHTTPRequest(eventReq)
+	if err != nil {
+		return lambdaResponse{}, err
+	}
+	w := httptest.NewRecorder()
+	handler.httpHandler.ServeHTTP(w, r)
+	return newLambdaResponse(w, handler.opts.binaryContentTypeMap)
+}
 
 // ListenAndServe starts the AWS Lambda runtime (aws-lambda-go lambda.Start) with a given handler.
 func ListenAndServe(handler http.Handler, opts *Options) {
@@ -30,7 +53,5 @@ func ListenAndServe(handler http.Handler, opts *Options) {
 		opts = defaultOptions
 	}
 	opts.setBinaryContentTypeMap()
-	lambda.Start(func(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-		return handleEvent(ctx, event, handler, opts)
-	})
+	lambda.StartHandler(lambdaHandler{httpHandler: handler, opts: opts})
 }

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -255,7 +255,7 @@ var apigwAdapterTestCases = []adapterTestCase{
 		opts: &Options{
 			RequestType: RequestTypeALB,
 		},
-		expectedErr: errNonALBEvent,
+		expectedErr: errALBUnexpectedRequest,
 	},
 }
 
@@ -283,7 +283,7 @@ var albAdapterTestCases = []adapterTestCase{
 		opts: &Options{
 			RequestType: RequestTypeAPIGateway,
 		},
-		expectedErr: errNonAPIGateway,
+		expectedErr: errAPIGatewayUnexpectedRequest,
 	},
 }
 

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -2,6 +2,7 @@ package algnhsa
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -9,17 +10,276 @@ import (
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
 )
 
-func assertDeepEqual(t *testing.T, expected interface{}, actual interface{}, testCase interface{}) {
-	t.Helper()
-	if !reflect.DeepEqual(expected, actual) {
-		t.Fatalf("\nexpected %+v\ngot      %+v\ntest case: %+v", expected, actual, testCase)
-	}
+const (
+	testModeAPIGW = iota
+	testModeALB
+)
+
+type adapterTestCase struct {
+	req      lambdaRequest
+	opts     *Options
+	resp     lambdaResponse
+	apigwReq events.APIGatewayProxyRequest
+	albReq   events.ALBTargetGroupRequest
 }
 
-func TestHandleEvent(t *testing.T) {
+var commonAdapterTestCases = []adapterTestCase{
+	{
+		req: lambdaRequest{
+			Path: "/html",
+		},
+		resp: lambdaResponse{
+			StatusCode:        200,
+			Body:              "<html>foo</html>",
+			MultiValueHeaders: map[string][]string{"Content-Type": {"text/html; charset=utf-8"}},
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/text",
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "ok",
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/query-params",
+			QueryStringParameters: map[string]string{
+				"a": "1",
+				"b": "",
+			},
+			MultiValueQueryStringParameters: map[string][]string{
+				"b": {"2"},
+				"c": {"31", "32", "33"},
+			},
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "a=[1], b=[2], c=[31 32 33], unknown=[]",
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/path/encode%2Ftest%7C",
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "/path/encode/test|",
+		},
+	},
+	{
+		req: lambdaRequest{
+			HTTPMethod: "POST",
+			Path:       "/post-body",
+			Body:       "foobar",
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "foobar",
+		},
+	},
+	{
+		req: lambdaRequest{
+			HTTPMethod:      "POST",
+			Path:            "/post-body",
+			Body:            "Zm9vYmFy",
+			IsBase64Encoded: true,
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "foobar",
+		},
+	},
+	{
+		req: lambdaRequest{
+			HTTPMethod: "POST",
+			Path:       "/form",
+			MultiValueHeaders: map[string][]string{
+				"Content-Type":   {"application/x-www-form-urlencoded"},
+				"Content-Length": {"19"},
+			},
+			Body: "f=foo&s=bar&xyz=123",
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "foobar",
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/status",
+		},
+		resp: lambdaResponse{
+			StatusCode:        204,
+			MultiValueHeaders: map[string][]string{"Content-Type": {"image/gif"}},
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/headers",
+			Headers: map[string]string{
+				"X-a": "1",
+				"x-b": "2",
+			},
+			MultiValueHeaders: map[string][]string{
+				"x-B": {"21", "22"},
+			},
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			MultiValueHeaders: map[string][]string{
+				"Content-Type": {"text/plain; charset=utf-8"},
+				"X-Bar":        {"baz"},
+				"X-Y":          {"1", "2"},
+			},
+			Body: "ok",
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/text",
+		},
+		opts: &Options{
+			BinaryContentTypes: []string{"text/plain; charset=utf-8"},
+		},
+		resp: lambdaResponse{
+			StatusCode:      200,
+			Body:            "b2s=",
+			IsBase64Encoded: true,
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/text",
+		},
+		opts: &Options{
+			BinaryContentTypes: []string{"*/*"},
+		},
+		resp: lambdaResponse{
+			StatusCode:      200,
+			Body:            "b2s=",
+			IsBase64Encoded: true,
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/text",
+		},
+		opts: &Options{
+			BinaryContentTypes: []string{"text/html; charset=utf-8"},
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "ok",
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/404",
+		},
+		resp: lambdaResponse{
+			StatusCode: 404,
+			Body:       "404 page not found\n",
+			MultiValueHeaders: map[string][]string{
+				"Content-Type":           {"text/plain; charset=utf-8"},
+				"X-Content-Type-Options": {"nosniff"},
+			},
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/hostname",
+			Headers: map[string]string{
+				"Host": "bar",
+			},
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			MultiValueHeaders: map[string][]string{
+				"Content-Type": {"text/plain; charset=utf-8"},
+			},
+			Body: "bar",
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/requesturi",
+			QueryStringParameters: map[string]string{
+				"foo": "bar",
+			},
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "/requesturi?foo=bar",
+		},
+	},
+}
+
+var apigwAdapterTestCases = []adapterTestCase{
+	{
+		req: lambdaRequest{
+			Path: "/apigw/text",
+		},
+		apigwReq: events.APIGatewayProxyRequest{
+			PathParameters: map[string]string{
+				"proxy": "text",
+			},
+		},
+		opts: &Options{
+			UseProxyPath: true,
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "ok",
+		},
+	},
+	{
+		req: lambdaRequest{
+			Path: "/apigw/context",
+		},
+		apigwReq: events.APIGatewayProxyRequest{
+			RequestContext: events.APIGatewayProxyRequestContext{
+				AccountID: "foo",
+			},
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "ok",
+		},
+	},
+}
+
+var albAdapterTestCases = []adapterTestCase{
+	{
+		req: lambdaRequest{
+			Path: "/alb/context",
+		},
+		albReq: events.ALBTargetGroupRequest{
+			RequestContext: events.ALBTargetGroupRequestContext{
+				ELB: events.ELBContext{
+					TargetGroupArn: "foo",
+				},
+			},
+		},
+		resp: lambdaResponse{
+			StatusCode: 200,
+			Body:       "ok",
+		},
+	},
+}
+
+func testHandle(t *testing.T, testCases []adapterTestCase, testMode int) {
+	t.Helper()
+	asrt := assert.New(t)
+
 	r := http.NewServeMux()
+
+	// Common handlers
 	r.HandleFunc("/html", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("<html>foo</html>"))
 	})
@@ -60,9 +320,18 @@ func TestHandleEvent(t *testing.T) {
 			w.Write([]byte("ok"))
 		}
 	})
-	r.HandleFunc("/context", func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc("/hostname", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.Host))
+	})
+	r.HandleFunc("/requesturi", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(r.RequestURI))
+	})
+
+	// APIGateway specific handlers
+	r.HandleFunc("/apigw/context", func(w http.ResponseWriter, r *http.Request) {
 		expectedProxyReq := events.APIGatewayProxyRequest{
-			Path: "/context",
+			HTTPMethod: "GET",
+			Path:       "/apigw/context",
 			RequestContext: events.APIGatewayProxyRequestContext{
 				AccountID: "foo",
 			},
@@ -72,255 +341,89 @@ func TestHandleEvent(t *testing.T) {
 			w.Write([]byte("ok"))
 		}
 	})
-	r.HandleFunc("/hostname", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(r.Host))
-	})
-	r.HandleFunc("/requesturi", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(r.RequestURI))
-	})
-	testCases := []struct {
-		req  events.APIGatewayProxyRequest
-		opts *Options
-		resp events.APIGatewayProxyResponse
-	}{
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/html",
+
+	// ALB specific handlers
+	r.HandleFunc("/alb/context", func(w http.ResponseWriter, r *http.Request) {
+		expectedProxyReq := events.ALBTargetGroupRequest{
+			HTTPMethod: "GET",
+			Path:       "/alb/context",
+			MultiValueHeaders: map[string][]string{
+				"X-Test": {"1"},
 			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode:        200,
-				Body:              "<html>foo</html>",
-				MultiValueHeaders: map[string][]string{"Content-Type": {"text/html; charset=utf-8"}},
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/text",
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "ok",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/query-params",
-				QueryStringParameters: map[string]string{
-					"a": "1",
-					"b": "",
-				},
-				MultiValueQueryStringParameters: map[string][]string{
-					"b": {"2"},
-					"c": {"31", "32", "33"},
+			RequestContext: events.ALBTargetGroupRequestContext{
+				ELB: events.ELBContext{
+					TargetGroupArn: "foo",
 				},
 			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "a=[1], b=[2], c=[31 32 33], unknown=[]",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/path/encode%2Ftest%7C",
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "/path/encode/test|",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				HTTPMethod: "POST",
-				Path:       "/post-body",
-				Body:       "foobar",
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "foobar",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				HTTPMethod:      "POST",
-				Path:            "/post-body",
-				Body:            "Zm9vYmFy",
-				IsBase64Encoded: true,
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "foobar",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				HTTPMethod: "POST",
-				Path:       "/form",
-				MultiValueHeaders: map[string][]string{
-					"Content-Type":   {"application/x-www-form-urlencoded"},
-					"Content-Length": {"19"},
-				},
-				Body: "f=foo&s=bar&xyz=123",
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "foobar",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/status",
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode:        204,
-				MultiValueHeaders: map[string][]string{"Content-Type": {"image/gif"}},
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/headers",
-				Headers: map[string]string{
-					"X-a": "1",
-					"x-b": "2",
-				},
-				MultiValueHeaders: map[string][]string{
-					"x-B": {"21", "22"},
-				},
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				MultiValueHeaders: map[string][]string{
-					"Content-Type": {"text/plain; charset=utf-8"},
-					"X-Bar":        {"baz"},
-					"X-Y":          {"1", "2"},
-				},
-				Body: "ok",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/text",
-			},
-			opts: &Options{
-				BinaryContentTypes: []string{"text/plain; charset=utf-8"},
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode:      200,
-				Body:            "b2s=",
-				IsBase64Encoded: true,
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/text",
-			},
-			opts: &Options{
-				BinaryContentTypes: []string{"*/*"},
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode:      200,
-				Body:            "b2s=",
-				IsBase64Encoded: true,
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/text",
-			},
-			opts: &Options{
-				BinaryContentTypes: []string{"text/html; charset=utf-8"},
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "ok",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/404",
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 404,
-				Body:       "404 page not found\n",
-				MultiValueHeaders: map[string][]string{
-					"Content-Type":           {"text/plain; charset=utf-8"},
-					"X-Content-Type-Options": {"nosniff"},
-				},
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/context",
-				RequestContext: events.APIGatewayProxyRequestContext{
-					AccountID: "foo",
-				},
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "ok",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/hostname",
-				Headers: map[string]string{
-					"Host": "bar",
-				},
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				MultiValueHeaders: map[string][]string{
-					"Content-Type": {"text/plain; charset=utf-8"},
-				},
-				Body: "bar",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/stage/text",
-				PathParameters: map[string]string{
-					"proxy": "text",
-				},
-			},
-			opts: &Options{
-				UseProxyPath: true,
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "ok",
-			},
-		},
-		{
-			req: events.APIGatewayProxyRequest{
-				Path: "/requesturi",
-				QueryStringParameters: map[string]string{
-					"foo": "bar",
-				},
-			},
-			resp: events.APIGatewayProxyResponse{
-				StatusCode: 200,
-				Body:       "/requesturi?foo=bar",
-			},
-		},
-	}
-	for _, testCase := range testCases {
-		req := testCase.req
-		if req.HTTPMethod == "" {
-			req.HTTPMethod = "GET"
 		}
+		targetReq, ok := TargetGroupRequestFromContext(r.Context())
+		if ok && reflect.DeepEqual(expectedProxyReq, targetReq) {
+			w.Write([]byte("ok"))
+		}
+	})
+
+	for _, testCase := range testCases {
+		lambdaReq := testCase.req
+		if lambdaReq.HTTPMethod == "" {
+			lambdaReq.HTTPMethod = "GET"
+		}
+
 		expectedResp := testCase.resp
 		if expectedResp.MultiValueHeaders == nil {
 			expectedResp.MultiValueHeaders = map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}}
 		}
+
+		lambdaPayload, err := json.Marshal(lambdaReq)
+		asrt.NoError(err)
+
+		var payload []byte
+		if testMode == testModeAPIGW {
+			req := testCase.apigwReq
+			err = json.Unmarshal(lambdaPayload, &req)
+			asrt.NoError(err)
+			if req.RequestContext.AccountID == "" {
+				req.RequestContext.AccountID = "test"
+			}
+			payload, err = json.Marshal(req)
+			asrt.NoError(err)
+		} else {
+			req := testCase.albReq
+			err := json.Unmarshal(lambdaPayload, &req)
+			asrt.NoError(err)
+			if req.RequestContext.ELB.TargetGroupArn == "" {
+				req.RequestContext.ELB.TargetGroupArn = "test"
+			}
+			if req.MultiValueHeaders == nil {
+				req.MultiValueHeaders = map[string][]string{
+					"X-Test": {"1"},
+				}
+			}
+			payload, err = json.Marshal(req)
+			asrt.NoError(err)
+		}
+
 		opts := testCase.opts
 		if opts == nil {
 			opts = defaultOptions
 		}
 		opts.setBinaryContentTypeMap()
-		ctx := context.Background()
-		resp, err := handleEvent(ctx, testCase.req, r, opts)
-		if err != nil {
-			t.Fatal(err)
-		}
-		assertDeepEqual(t, expectedResp, resp, testCase)
+		handler := lambdaHandler{httpHandler: r, opts: opts}
+		resp, err := handler.handleEvent(context.Background(), payload)
+		asrt.NoError(err)
+		asrt.EqualValues(expectedResp, resp, testCase)
 	}
+}
+
+func TestHandleAPIGateway(t *testing.T) {
+	var testCases []adapterTestCase
+	testCases = append(testCases, commonAdapterTestCases...)
+	testCases = append(testCases, apigwAdapterTestCases...)
+	testHandle(t, testCases, testModeAPIGW)
+}
+
+func TestHandleALB(t *testing.T) {
+	var testCases []adapterTestCase
+	testCases = append(testCases, commonAdapterTestCases...)
+	testCases = append(testCases, albAdapterTestCases...)
+	testHandle(t, testCases, testModeALB)
 }

--- a/alb.go
+++ b/alb.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	errNonALBEvent                  = errors.New("non ALBTargetGroupRequest event")
+	errALBUnexpectedRequest         = errors.New("expected ALBTargetGroupRequest")
 	errALBExpectedMultiValueHeaders = errors.New("expected multi value headers; enable Multi value headers in target group settings")
 )
 
@@ -30,7 +30,7 @@ func newALBRequest(ctx context.Context, payload []byte, opts *Options) (lambdaRe
 		return lambdaRequest{}, err
 	}
 	if event.RequestContext.ELB.TargetGroupArn == "" {
-		return lambdaRequest{}, errNonALBEvent
+		return lambdaRequest{}, errALBUnexpectedRequest
 	}
 	if len(event.MultiValueHeaders) == 0 {
 		return lambdaRequest{}, errALBExpectedMultiValueHeaders

--- a/alb.go
+++ b/alb.go
@@ -36,17 +36,18 @@ func newALBRequest(ctx context.Context, payload []byte, opts *Options) (lambdaRe
 		return lambdaRequest{}, errALBExpectedMultiValueHeaders
 	}
 
-	req := lambdaRequest{}
-	req.HTTPMethod = event.HTTPMethod
-	req.Path = event.Path
-	req.QueryStringParameters = event.QueryStringParameters
-	req.MultiValueQueryStringParameters = event.MultiValueQueryStringParameters
-	req.Headers = event.Headers
-	req.MultiValueHeaders = event.MultiValueHeaders
-	req.Body = event.Body
-	req.IsBase64Encoded = event.IsBase64Encoded
-	req.SourceIP = getALBSourceIP(event)
-	req.Context = newTargetGroupRequestContext(ctx, event)
+	req := lambdaRequest{
+		HTTPMethod:                      event.HTTPMethod,
+		Path:                            event.Path,
+		QueryStringParameters:           event.QueryStringParameters,
+		MultiValueQueryStringParameters: event.MultiValueQueryStringParameters,
+		Headers:                         event.Headers,
+		MultiValueHeaders:               event.MultiValueHeaders,
+		Body:                            event.Body,
+		IsBase64Encoded:                 event.IsBase64Encoded,
+		SourceIP:                        getALBSourceIP(event),
+		Context:                         newTargetGroupRequestContext(ctx, event),
+	}
 
 	return req, nil
 }

--- a/alb.go
+++ b/alb.go
@@ -1,0 +1,52 @@
+package algnhsa
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+var (
+	errNonALBEvent                  = errors.New("non ALBTargetGroupRequest event")
+	errALBExpectedMultiValueHeaders = errors.New("expected multi value headers; enable Multi value headers in target group settings")
+)
+
+func getALBSourceIP(event events.ALBTargetGroupRequest) string {
+	if xff, ok := event.MultiValueHeaders["x-forwarded-for"]; ok && len(xff) > 0 {
+		ips := strings.SplitN(xff[0], ",", 2)
+		if len(ips) > 0 {
+			return ips[0]
+		}
+	}
+	return ""
+}
+
+func newALBRequest(ctx context.Context, payload []byte, opts *Options) (lambdaRequest, error) {
+	var event events.ALBTargetGroupRequest
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return lambdaRequest{}, err
+	}
+	if event.RequestContext.ELB.TargetGroupArn == "" {
+		return lambdaRequest{}, errNonALBEvent
+	}
+	if len(event.MultiValueHeaders) == 0 {
+		return lambdaRequest{}, errALBExpectedMultiValueHeaders
+	}
+
+	req := lambdaRequest{}
+	req.HTTPMethod = event.HTTPMethod
+	req.Path = event.Path
+	req.QueryStringParameters = event.QueryStringParameters
+	req.MultiValueQueryStringParameters = event.MultiValueQueryStringParameters
+	req.Headers = event.Headers
+	req.MultiValueHeaders = event.MultiValueHeaders
+	req.Body = event.Body
+	req.IsBase64Encoded = event.IsBase64Encoded
+	req.SourceIP = getALBSourceIP(event)
+	req.Context = newTargetGroupRequestContext(ctx, event)
+
+	return req, nil
+}

--- a/apigw.go
+++ b/apigw.go
@@ -22,22 +22,22 @@ func newAPIGatewayRequest(ctx context.Context, payload []byte, opts *Options) (l
 		return lambdaRequest{}, errNonAPIGateway
 	}
 
-	req := lambdaRequest{}
-	req.HTTPMethod = event.HTTPMethod
-	if opts.UseProxyPath {
-		req.Path = path.Join("/", event.PathParameters["proxy"])
-	} else {
-		req.Path = event.Path
+	req := lambdaRequest{
+		HTTPMethod:                      event.HTTPMethod,
+		Path:                            event.Path,
+		QueryStringParameters:           event.QueryStringParameters,
+		MultiValueQueryStringParameters: event.MultiValueQueryStringParameters,
+		Headers:                         event.Headers,
+		MultiValueHeaders:               event.MultiValueHeaders,
+		Body:                            event.Body,
+		IsBase64Encoded:                 event.IsBase64Encoded,
+		SourceIP:                        event.RequestContext.Identity.SourceIP,
+		Context:                         newProxyRequestContext(ctx, event),
 	}
 
-	req.QueryStringParameters = event.QueryStringParameters
-	req.MultiValueQueryStringParameters = event.MultiValueQueryStringParameters
-	req.Headers = event.Headers
-	req.MultiValueHeaders = event.MultiValueHeaders
-	req.Body = event.Body
-	req.IsBase64Encoded = event.IsBase64Encoded
-	req.SourceIP = event.RequestContext.Identity.SourceIP
-	req.Context = newProxyRequestContext(ctx, event)
+	if opts.UseProxyPath {
+		req.Path = path.Join("/", event.PathParameters["proxy"])
+	}
 
 	return req, nil
 }

--- a/apigw.go
+++ b/apigw.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	errNonAPIGateway = errors.New("non APIGatewayProxyRequest event")
+	errAPIGatewayUnexpectedRequest = errors.New("expected APIGatewayProxyRequest event")
 )
 
 func newAPIGatewayRequest(ctx context.Context, payload []byte, opts *Options) (lambdaRequest, error) {
@@ -19,7 +19,7 @@ func newAPIGatewayRequest(ctx context.Context, payload []byte, opts *Options) (l
 		return lambdaRequest{}, err
 	}
 	if event.RequestContext.AccountID == "" {
-		return lambdaRequest{}, errNonAPIGateway
+		return lambdaRequest{}, errAPIGatewayUnexpectedRequest
 	}
 
 	req := lambdaRequest{

--- a/apigw.go
+++ b/apigw.go
@@ -1,0 +1,43 @@
+package algnhsa
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+var (
+	errNonAPIGateway = errors.New("non APIGatewayProxyRequest event")
+)
+
+func newAPIGatewayRequest(ctx context.Context, payload []byte, opts *Options) (lambdaRequest, error) {
+	var event events.APIGatewayProxyRequest
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return lambdaRequest{}, err
+	}
+	if event.RequestContext.AccountID == "" {
+		return lambdaRequest{}, errNonAPIGateway
+	}
+
+	req := lambdaRequest{}
+	req.HTTPMethod = event.HTTPMethod
+	if opts.UseProxyPath {
+		req.Path = path.Join("/", event.PathParameters["proxy"])
+	} else {
+		req.Path = event.Path
+	}
+
+	req.QueryStringParameters = event.QueryStringParameters
+	req.MultiValueQueryStringParameters = event.MultiValueQueryStringParameters
+	req.Headers = event.Headers
+	req.MultiValueHeaders = event.MultiValueHeaders
+	req.Body = event.Body
+	req.IsBase64Encoded = event.IsBase64Encoded
+	req.SourceIP = event.RequestContext.Identity.SourceIP
+	req.Context = newProxyRequestContext(ctx, event)
+
+	return req, nil
+}

--- a/context.go
+++ b/context.go
@@ -6,16 +6,37 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-type key int
+type contextKey int
 
-const requestContextKey key = 0
+const (
+	proxyRequestContextKey contextKey = iota
+	albRequestContextKey
+)
 
-func newContext(ctx context.Context, event events.APIGatewayProxyRequest) context.Context {
-	return context.WithValue(ctx, requestContextKey, event)
+func newProxyRequestContext(ctx context.Context, event events.APIGatewayProxyRequest) context.Context {
+	return context.WithValue(ctx, proxyRequestContextKey, event)
 }
 
 // ProxyRequestFromContext extracts the APIGatewayProxyRequest event from ctx.
 func ProxyRequestFromContext(ctx context.Context) (events.APIGatewayProxyRequest, bool) {
-	event, ok := ctx.Value(requestContextKey).(events.APIGatewayProxyRequest)
+	val := ctx.Value(proxyRequestContextKey)
+	if val == nil {
+		return events.APIGatewayProxyRequest{}, false
+	}
+	event, ok := val.(events.APIGatewayProxyRequest)
+	return event, ok
+}
+
+func newTargetGroupRequestContext(ctx context.Context, event events.ALBTargetGroupRequest) context.Context {
+	return context.WithValue(ctx, albRequestContextKey, event)
+}
+
+// TargetGroupRequestFromContext extracts the ALBTargetGroupRequest event from ctx.
+func TargetGroupRequestFromContext(ctx context.Context) (events.ALBTargetGroupRequest, bool) {
+	val := ctx.Value(albRequestContextKey)
+	if val == nil {
+		return events.ALBTargetGroupRequest{}, false
+	}
+	event, ok := val.(events.ALBTargetGroupRequest)
 	return event, ok
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.12
 
 require (
 	github.com/aws/aws-lambda-go v1.9.0
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 )

--- a/options.go
+++ b/options.go
@@ -1,7 +1,19 @@
 package algnhsa
 
+type RequestType int
+
+const (
+	RequestTypeAuto RequestType = iota
+	RequestTypeAPIGateway
+	RequestTypeALB
+)
+
 // Options holds the optional parameters.
 type Options struct {
+	// RequestType sets the expected request type.
+	// By default algnhsa deduces the request type from the lambda function payload.
+	RequestType RequestType
+
 	// BinaryContentTypes sets content types that should be treated as binary types by API Gateway.
 	// The "*/* value makes algnhsa treat any content type as binary.
 	BinaryContentTypes   []string

--- a/options.go
+++ b/options.go
@@ -14,7 +14,7 @@ type Options struct {
 	// By default algnhsa deduces the request type from the lambda function payload.
 	RequestType RequestType
 
-	// BinaryContentTypes sets content types that should be treated as binary types by API Gateway.
+	// BinaryContentTypes sets content types that should be treated as binary types.
 	// The "*/* value makes algnhsa treat any content type as binary.
 	BinaryContentTypes   []string
 	binaryContentTypeMap map[string]bool

--- a/request.go
+++ b/request.go
@@ -24,6 +24,15 @@ type lambdaRequest struct {
 }
 
 func newLambdaRequest(ctx context.Context, payload []byte, opts *Options) (lambdaRequest, error) {
+	switch opts.RequestType {
+	case RequestTypeAPIGateway:
+		return newAPIGatewayRequest(ctx, payload, opts)
+	case RequestTypeALB:
+		return newALBRequest(ctx, payload, opts)
+	}
+
+	// The request type wasn't specified.
+	// Try to decode the payload as APIGatewayProxyRequest, if it fails try ALBTargetGroupRequest.
 	req, err := newAPIGatewayRequest(ctx, payload, opts)
 	if err != nil && err != errNonAPIGateway {
 		return lambdaRequest{}, err

--- a/request.go
+++ b/request.go
@@ -3,16 +3,47 @@ package algnhsa
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
-
-	"github.com/aws/aws-lambda-go/events"
 )
 
-func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, useProxyPath bool) (*http.Request, error) {
+type lambdaRequest struct {
+	HTTPMethod                      string              `json:"httpMethod"`
+	Path                            string              `json:"path"`
+	QueryStringParameters           map[string]string   `json:"queryStringParameters,omitempty"`
+	MultiValueQueryStringParameters map[string][]string `json:"multiValueQueryStringParameters,omitempty"`
+	Headers                         map[string]string   `json:"headers,omitempty"`
+	MultiValueHeaders               map[string][]string `json:"multiValueHeaders,omitempty"`
+	IsBase64Encoded                 bool                `json:"isBase64Encoded"`
+	Body                            string              `json:"body"`
+	SourceIP                        string
+	Context                         context.Context
+}
+
+func newLambdaRequest(ctx context.Context, payload []byte, opts *Options) (lambdaRequest, error) {
+	req, err := newAPIGatewayRequest(ctx, payload, opts)
+	if err != nil && err != errNonAPIGateway {
+		return lambdaRequest{}, err
+	}
+	if err == nil {
+		return req, nil
+	}
+
+	req, err = newALBRequest(ctx, payload, opts)
+	if err != nil && err != errNonALBEvent {
+		return lambdaRequest{}, err
+	}
+	if err == nil {
+		return req, nil
+	}
+
+	return lambdaRequest{}, errors.New("neither APIGatewayProxyRequest nor ALBTargetGroupRequest received")
+}
+
+func newHTTPRequest(event lambdaRequest) (*http.Request, error) {
 	// Build request URL.
 	params := url.Values{}
 	for k, v := range event.QueryStringParameters {
@@ -22,13 +53,23 @@ func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, us
 		params[k] = vals
 	}
 
+	// Set headers.
+	// https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
+	// If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list.
+	// If the same key-value pair is specified in both, only the values from multiValueHeaders will appear
+	// the merged list.
+	headers := make(http.Header)
+	for k, v := range event.Headers {
+		headers.Set(k, v)
+	}
+	for k, vals := range event.MultiValueHeaders {
+		headers[http.CanonicalHeaderKey(k)] = vals
+	}
+
 	u := url.URL{
-		Host:     event.Headers["Host"],
+		Host:     headers.Get("host"),
 		RawPath:  event.Path,
 		RawQuery: params.Encode(),
-	}
-	if useProxyPath {
-		u.RawPath = path.Join("/", event.PathParameters["proxy"])
 	}
 
 	// Unescape request path
@@ -49,28 +90,18 @@ func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest, us
 	}
 
 	// Create a new request.
-	r, err := http.NewRequest(event.HTTPMethod, u.String(), body)
+	r, err := http.NewRequestWithContext(event.Context, event.HTTPMethod, u.String(), body)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set headers.
-	// https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html
-	// If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list.
-	// If the same key-value pair is specified in both, only the values from multiValueHeaders will appear
-	// the merged list.
-	for k, v := range event.Headers {
-		r.Header.Set(k, v)
-	}
-	for k, vals := range event.MultiValueHeaders {
-		r.Header[http.CanonicalHeaderKey(k)] = vals
-	}
-
 	// Set remote IP address.
-	r.RemoteAddr = event.RequestContext.Identity.SourceIP
+	r.RemoteAddr = event.SourceIP
 
 	// Set request URI
 	r.RequestURI = u.RequestURI()
 
-	return r.WithContext(newContext(ctx, event)), nil
+	r.Header = headers
+
+	return r, nil
 }

--- a/request.go
+++ b/request.go
@@ -34,7 +34,7 @@ func newLambdaRequest(ctx context.Context, payload []byte, opts *Options) (lambd
 	// The request type wasn't specified.
 	// Try to decode the payload as APIGatewayProxyRequest, if it fails try ALBTargetGroupRequest.
 	req, err := newAPIGatewayRequest(ctx, payload, opts)
-	if err != nil && err != errNonAPIGateway {
+	if err != nil && err != errAPIGatewayUnexpectedRequest {
 		return lambdaRequest{}, err
 	}
 	if err == nil {
@@ -42,7 +42,7 @@ func newLambdaRequest(ctx context.Context, payload []byte, opts *Options) (lambd
 	}
 
 	req, err = newALBRequest(ctx, payload, opts)
-	if err != nil && err != errNonALBEvent {
+	if err != nil && err != errALBUnexpectedRequest {
 		return lambdaRequest{}, err
 	}
 	if err == nil {

--- a/response.go
+++ b/response.go
@@ -3,14 +3,20 @@ package algnhsa
 import (
 	"encoding/base64"
 	"net/http/httptest"
-
-	"github.com/aws/aws-lambda-go/events"
 )
 
 const acceptAllContentType = "*/*"
 
-func newAPIGatewayResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool) (events.APIGatewayProxyResponse, error) {
-	event := events.APIGatewayProxyResponse{}
+type lambdaResponse struct {
+	StatusCode        int                 `json:"statusCode"`
+	Headers           map[string]string   `json:"headers"`
+	MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
+	Body              string              `json:"body"`
+	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
+}
+
+func newLambdaResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool) (lambdaResponse, error) {
+	event := lambdaResponse{}
 
 	// Set status code.
 	event.StatusCode = w.Code


### PR DESCRIPTION
Here is another approach I used to add ALB support. Previous PR https://github.com/akrylysov/algnhsa/pull/19.

I added a new intermediate structure `lambdaRequest`, both `APIGatewayProxyRequest` and `ALBTargetGroupRequest` are converted into it first. My primary goal was to avoid code duplication.

@adimarco @ARolek 