### PR TITLE
ProxyRequestContextKey const available from package

### DIFF
--- a/context.go
+++ b/context.go
@@ -9,17 +9,20 @@ import (
 type contextKey int
 
 const (
-	proxyRequestContextKey contextKey = iota
+	// ProxyRequestContextKey is useful for creating custom claims when testing locally
+	// ctx := context.WithValue(r.Context(), algnhsa.ProxyRequestKey, customLocalClaims)
+	// r = r.Clone(ctx)
+	ProxyRequestContextKey contextKey = iota
 	albRequestContextKey
 )
 
 func newProxyRequestContext(ctx context.Context, event events.APIGatewayProxyRequest) context.Context {
-	return context.WithValue(ctx, proxyRequestContextKey, event)
+	return context.WithValue(ctx, ProxyRequestContextKey, event)
 }
 
 // ProxyRequestFromContext extracts the APIGatewayProxyRequest event from ctx.
 func ProxyRequestFromContext(ctx context.Context) (events.APIGatewayProxyRequest, bool) {
-	val := ctx.Value(proxyRequestContextKey)
+	val := ctx.Value(ProxyRequestContextKey)
 	if val == nil {
 		return events.APIGatewayProxyRequest{}, false
 	}

--- a/context.go
+++ b/context.go
@@ -9,20 +9,24 @@ import (
 type contextKey int
 
 const (
-	// ProxyRequestContextKey is useful for creating custom claims when testing locally
-	// ctx := context.WithValue(r.Context(), algnhsa.ProxyRequestKey, customLocalClaims)
-	// r = r.Clone(ctx)
-	ProxyRequestContextKey contextKey = iota
+	proxyRequestContextKey contextKey = iota
 	albRequestContextKey
 )
 
+// GetProxyRequestContextKey is useful for creating custom claims when testing locally
+// ctx := context.WithValue(r.Context(), algnhsa.GetProxyRequestContextKey(), customLocalClaims)
+// r = r.Clone(ctx)
+func GetProxyRequestContextKey() contextKey {
+	return proxyRequestContextKey
+}
+
 func newProxyRequestContext(ctx context.Context, event events.APIGatewayProxyRequest) context.Context {
-	return context.WithValue(ctx, ProxyRequestContextKey, event)
+	return context.WithValue(ctx, proxyRequestContextKey, event)
 }
 
 // ProxyRequestFromContext extracts the APIGatewayProxyRequest event from ctx.
 func ProxyRequestFromContext(ctx context.Context) (events.APIGatewayProxyRequest, bool) {
-	val := ctx.Value(ProxyRequestContextKey)
+	val := ctx.Value(proxyRequestContextKey)
 	if val == nil {
 		return events.APIGatewayProxyRequest{}, false
 	}

--- a/context.go
+++ b/context.go
@@ -6,17 +6,18 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-type contextKey int
+// ContextKey type used to get/set items from request context
+type ContextKey int
 
 const (
-	proxyRequestContextKey contextKey = iota
+	proxyRequestContextKey ContextKey = iota
 	albRequestContextKey
 )
 
 // GetProxyRequestContextKey is useful for creating custom claims when testing locally
 // ctx := context.WithValue(r.Context(), algnhsa.GetProxyRequestContextKey(), customLocalClaims)
 // r = r.Clone(ctx)
-func GetProxyRequestContextKey() contextKey {
+func GetProxyRequestContextKey() ContextKey {
 	return proxyRequestContextKey
 }
 


### PR DESCRIPTION
Not sure if anyone else has run into this.

But running the Lambda function locally i need to be able to set the Lambda APIGatewayProxyRequest manually. Having access to the `algnhsa.ProxyRequestKey` would be very valuable.

For example, decoding accessId from cognito
```
func CreateFakeLambdaContext(next http.Handler) http.Handler {
    // return handler code

     // get token from header
     tokenString := r.Header.Get("Authorization")
     token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
      // parse token etc
  }

   // create custom claims from AccessToken
   customClaims := createFromToken(token)
   // create new APIGatewayProxyRequest
   localAPIGatewayProxyRequest := createLocalFromClaims(customClaims)

    ctx := context.WithValue(r.Context(), algnhsa.GetProxyRequestContextKey(), localAPIGatewayProxyRequest)
    r = r.Clone(ctx)
    next.ServeHTTP(w,r)
}
```

Let me know what you guys think