### PR TITLE
Set Headers in addition to MultiValueHeaders

### DIFF
--- a/response.go
+++ b/response.go
@@ -3,6 +3,7 @@ package algnhsa
 import (
 	"encoding/base64"
 	"net/http/httptest"
+	"strings"
 )
 
 const acceptAllContentType = "*/*"
@@ -23,6 +24,10 @@ func newLambdaResponse(w *httptest.ResponseRecorder, binaryContentTypes map[stri
 
 	// Set headers.
 	event.MultiValueHeaders = w.Result().Header
+	event.Headers = make(map[string]string, len(w.Result().Header))
+	for key, values := range w.Result().Header {
+		event.Headers[key] = strings.Join(values, ",")
+	}
 
 	// Set body.
 	contentType := w.Header().Get("Content-Type")


### PR DESCRIPTION
It appears that when using [Lambda function URLs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html) (which are essentially [APIGatewayV2HTTPRequest](https://pkg.go.dev/github.com/aws/aws-lambda-go@v1.34.1/events#APIGatewayV2HTTPRequest) structs) the `multiValueHeaders` value is ignored. Instead only the `headers` value is used. 

This PR populates the `headers` field not just the `multiValueHeaders`. I'm not clear if this should be configurable behind an option or not.