### PR TITLE
implement New function to return lambda.Handler from http.Handler

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -10,6 +10,19 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
+// New returns a new lambda handler for the given http.Handler.
+// It is up to the caller of New to run lamdba.Start(handler) with the returned handler.
+func New(handler http.Handler, opts *Options) lambda.Handler {
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+	if opts == nil {
+		opts = defaultOptions
+	}
+	opts.setBinaryContentTypeMap()
+	return lambdaHandler{httpHandler: handler, opts: opts}
+}
+
 var defaultOptions = &Options{}
 
 type lambdaHandler struct {


### PR DESCRIPTION
In addition to exposing a function `ListenAndServe` which calls `lambda.StartHandler` for the user of this library, this change exposes a function `New` which returns a `lambda.Handler`

The motivation for this change is to support usage of this library in a context where the http lambda function is being adapted by multiple layers (middleware)

For example, integrating datadog requires that you pass the lambda function to `ddlambda.WrapFunction(handler, nil)` before calling `lambda.Start` which is impossible if this library calls `lambda.Start` for you

I envision something like
```golang
router := newRouter()
handler := algnhsa.New(router, &algnhsa.Options{
	DebugLog: true,
})
lambda.Start(handler.Invoke)
```