### PR TITLE
feat: append Content-Encoding setting to applied IsBase64Encoded setup

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -55,7 +55,7 @@ func (handler lambdaHandler) handleEvent(ctx context.Context, payload []byte) (l
 	}
 	w := httptest.NewRecorder()
 	handler.httpHandler.ServeHTTP(w, r)
-	return newLambdaResponse(w, handler.opts.binaryContentTypeMap, eventReq.requestType)
+	return newLambdaResponse(w, handler.opts.binaryContentTypeMap, handler.opts.binaryContentEncodingMap, eventReq.requestType)
 }
 
 // ListenAndServe starts the AWS Lambda runtime (aws-lambda-go lambda.Start) with a given handler.

--- a/options.go
+++ b/options.go
@@ -20,6 +20,11 @@ type Options struct {
 	BinaryContentTypes   []string
 	binaryContentTypeMap map[string]bool
 
+	// BinaryContentEncoding sets the encoding for binary content.
+	// The "*" value makes algnhsa treat any content encoding as binary.
+	BinaryContentEncoding    []string
+	binaryContentEncodingMap map[string]bool
+
 	// Use API Gateway PathParameters["proxy"] when constructing the request url.
 	// Strips the base path mapping when using a custom domain with API Gateway.
 	UseProxyPath bool
@@ -34,4 +39,10 @@ func (opts *Options) setBinaryContentTypeMap() {
 		types[contentType] = true
 	}
 	opts.binaryContentTypeMap = types
+
+	encodings := map[string]bool{}
+	for _, encoding := range opts.BinaryContentEncoding {
+		encodings[encoding] = true
+	}
+	opts.binaryContentEncodingMap = encodings
 }

--- a/response.go
+++ b/response.go
@@ -6,7 +6,10 @@ import (
 	"net/http/httptest"
 )
 
-const acceptAllContentType = "*/*"
+const (
+	acceptAllContentType     = "*/*"
+	acceptAllContentEncoding = "*"
+)
 
 var canonicalSetCookieHeaderKey = http.CanonicalHeaderKey("Set-Cookie")
 
@@ -21,7 +24,7 @@ type lambdaResponse struct {
 	IsBase64Encoded   bool                `json:"isBase64Encoded,omitempty"`
 }
 
-func newLambdaResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool, requestType RequestType) (lambdaResponse, error) {
+func newLambdaResponse(w *httptest.ResponseRecorder, binaryContentTypes map[string]bool, binaryContentEncoding map[string]bool, requestType RequestType) (lambdaResponse, error) {
 	result := w.Result()
 
 	var resp lambdaResponse
@@ -42,7 +45,8 @@ func newLambdaResponse(w *httptest.ResponseRecorder, binaryContentTypes map[stri
 
 	// Set body.
 	contentType := result.Header.Get("Content-Type")
-	if binaryContentTypes[acceptAllContentType] || binaryContentTypes[contentType] {
+	contentEncoding := result.Header.Get("Content-Encoding")
+	if binaryContentTypes[acceptAllContentType] || binaryContentTypes[contentType] || binaryContentEncoding[acceptAllContentEncoding] || binaryContentEncoding[contentEncoding] {
 		resp.Body = base64.StdEncoding.EncodeToString(w.Body.Bytes())
 		resp.IsBase64Encoded = true
 	} else {


### PR DESCRIPTION
This PR enhances binary content handling by appending support for Content-Encoding in determining if the response body should be base64-encoded.

### Changes

Extended the existing lambdaResponse logic to include checks against a new BinaryContentEncoding option.

Added BinaryContentEncoding configuration in Options, allowing users to define which encodings are treated as binary.

Updated unit tests to verify correct base64 encoding behavior for responses based on Content-Encoding.

### Motivation

This change ensures proper handling of HTTP responses that utilize content encoding (e.g., gzip). It allows for more flexible and correct responses from AWS Lambda handlers.

### Test Plan

Unit tests have been added for various scenarios:

Match specific content encoding (gzip)

Match wildcard encoding (*)

Verify behavior when encoding does not match

All new tests pass, and existing tests remain unaffected.